### PR TITLE
Q2 2026 — System.Text.Json migration + quarterly work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,16 +55,26 @@ jobs:
           $deps = $buildOrder[0..($buildOrder.Count-2)]
           foreach ($r in $deps) {
             if (Test-Path $r) { continue }
-            $preferredBranch = 'sow/2026-Q2'
-            $hasPreferred = (git ls-remote --heads "https://github.com/$org/$r.git" $preferredBranch 2>$null | Out-String).Trim()
-            if ($hasPreferred) {
-              Write-Host "Cloning $org/$r @ $preferredBranch"
-              git clone --depth 1 --branch $preferredBranch "https://github.com/$org/$r.git" $r
-            } else {
+            $headRef = '${{ github.head_ref }}'
+            $candidates = @()
+            if ($headRef) { $candidates += $headRef }
+            $candidates += 'sow/2026-Q2'
+            $cloned = $false
+            foreach ($cand in $candidates) {
+              $has = (git ls-remote --heads "https://github.com/$org/$r.git" $cand 2>$null | Out-String).Trim()
+              if ($has) {
+                Write-Host "Cloning $org/$r @ $cand"
+                git clone --depth 1 --branch $cand "https://github.com/$org/$r.git" $r
+                $cloned = $true
+                break
+              }
+            }
+            if (-not $cloned) {
               Write-Host "Cloning $org/$r @ default branch"
               git clone --depth 1 "https://github.com/$org/$r.git" $r
             }
           }
+
 
           # Ensure ReferencePath exists even before SAM_Windows builds
           New-Item -ItemType Directory -Force -Path "SAM_Windows\build" | Out-Null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build (Windows)
 
 on:
   push:
-    branches: [ "master", "main", "sow/2026-Q2" ]
+    branches: [ "master", "main", "sow/**" ]
   pull_request:
-    branches: [ "master", "main", "sow/2026-Q2" ]
+    branches: [ "master", "main", "sow/**" ]
   workflow_dispatch:
 
 jobs:
@@ -35,6 +35,36 @@ jobs:
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
+      - name: Compute SAMVersion
+        id: ver
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # Prefer head_ref when its a sow branch (release-promotion PRs from sow/* to main),
+          # else use base_ref on PR events / ref_name on push events.
+          $headRef = '${{ github.head_ref }}'
+          $baseRef = '${{ github.base_ref }}'
+          $refName = '${{ github.ref_name }}'
+          if ($headRef -match '^sow/\d{4}-Q\d$') {
+            $ref = $headRef
+          } elseif ('${{ github.event_name }}' -eq 'pull_request') {
+            $ref = $baseRef
+          } else {
+            $ref = $refName
+          }
+          # .NET AssemblyVersion components are UInt16 (max 65535). Cap to 60000 for headroom.
+          $run = ${{ github.run_number }} % 60000
+          if ($ref -match 'sow/(\d{4})-Q(\d)') {
+            $v = "$($Matches[1]).$($Matches[2]).$run.0"
+            $src = "branch '$ref'"
+          } else {
+            $now = (Get-Date).ToUniversalTime()
+            $quarter = [int][Math]::Ceiling($now.Month / 3.0)
+            $v = "$($now.Year).$quarter.$run.0"
+            $src = "date $($now.ToString('yyyy-MM-dd')) (ref '$ref' not sow/yyyy-Qx)"
+          }
+          Write-Host "SAMVersion = $v (from $src)"
+          "samversion=$v" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Clone dependency repos (siblings)
         shell: pwsh
@@ -56,8 +86,13 @@ jobs:
           foreach ($r in $deps) {
             if (Test-Path $r) { continue }
             $headRef = '${{ github.head_ref }}'
+            $baseRef = '${{ github.base_ref }}'
+            $refName = '${{ github.ref_name }}'
             $candidates = @()
             if ($headRef) { $candidates += $headRef }
+            # Current sow branch: base_ref on PR events, ref_name on push events.
+            $sowRef = if ($baseRef -match '^sow/') { $baseRef } elseif ($refName -match '^sow/') { $refName } else { '' }
+            if ($sowRef -and $sowRef -ne $headRef) { $candidates += $sowRef }
             $candidates += 'sow/2026-Q2'
             $cloned = $false
             foreach ($cand in $candidates) {
@@ -94,6 +129,7 @@ jobs:
             '/v:m'
             '/p:Configuration=Release'
             '/p:UseSharedCompilation=false'
+            '/p:SAMVersion=${{ steps.ver.outputs.samversion }}'
             '/p:RunPostBuildEvent=OnOutputUpdated'
             "/p:ReferencePath=$windowsRef"
           )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build (Windows)
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main", "sow/2026-Q2" ]
   pull_request:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main", "sow/2026-Q2" ]
   workflow_dispatch:
 
 jobs:
@@ -55,8 +55,15 @@ jobs:
           $deps = $buildOrder[0..($buildOrder.Count-2)]
           foreach ($r in $deps) {
             if (Test-Path $r) { continue }
-            Write-Host "Cloning https://github.com/$org/$r.git"
-            git clone --depth 1 "https://github.com/$org/$r.git" $r
+            $preferredBranch = 'sow/2026-Q2'
+            $hasPreferred = (git ls-remote --heads "https://github.com/$org/$r.git" $preferredBranch 2>$null | Out-String).Trim()
+            if ($hasPreferred) {
+              Write-Host "Cloning $org/$r @ $preferredBranch"
+              git clone --depth 1 --branch $preferredBranch "https://github.com/$org/$r.git" $r
+            } else {
+              Write-Host "Cloning $org/$r @ default branch"
+              git clone --depth 1 "https://github.com/$org/$r.git" $r
+            }
           }
 
           # Ensure ReferencePath exists even before SAM_Windows builds

--- a/.github/workflows/spdx-check.yml
+++ b/.github/workflows/spdx-check.yml
@@ -2,44 +2,89 @@ name: SPDX + Copyright header check
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   spdx:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Check header in changed .cs files
+        shell: bash
         run: |
-          set -e
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
+          set -euo pipefail
 
-          FILES=$(git diff --name-only "$BASE" "$HEAD" -- '*.cs' || true)
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            HEAD="${{ github.sha }}"
+            BASE="$(git rev-parse "${HEAD}^" 2>/dev/null || true)"
+          fi
 
-          if [ -z "$FILES" ]; then
+          echo "Base SHA: ${BASE:-<none>}"
+          echo "Head SHA: $HEAD"
+          echo
+
+          if [ -z "${BASE:-}" ]; then
+            mapfile -t files < <(git ls-files '*.cs')
+          else
+            mapfile -t files < <(git diff --diff-filter=ACMR --name-only "$BASE" "$HEAD" -- '*.cs' || true)
+          fi
+
+          if [ "${#files[@]}" -eq 0 ]; then
             echo "No C# files changed."
             exit 0
           fi
 
-          MISSING=""
-          for f in $FILES; do
-            HEADBLOCK=$(head -n 6 "$f")
+          echo "Changed C# files:"
+          printf ' - %s\n' "${files[@]}"
+          echo
 
-            echo "$HEADBLOCK" | grep -q "// SPDX-License-Identifier: LGPL-3.0-or-later" || MISSING="$MISSING $f"
-            echo "$HEADBLOCK" | grep -q "// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors" || MISSING="$MISSING $f"
+          missing=()
+
+          for f in "${files[@]}"; do
+            if [ ! -f "$f" ]; then
+              echo "Skipping missing file: $f"
+              continue
+            fi
+
+            headblock="$(head -n 20 "$f" | sed '1s/^\xEF\xBB\xBF//' | tr -d '\r')"
+
+            echo "Checking: $f"
+
+            if ! grep -q "SPDX-License-Identifier: LGPL-3.0-or-later" <<< "$headblock"; then
+              echo "  Missing SPDX line"
+              missing+=("$f")
+              continue
+            fi
+
+            if ! grep -qE "Copyright \(c\) 2020[-–]2026 Michal Dengusiak & Jakub Ziolkowski and contributors" <<< "$headblock"; then
+              echo "  Missing copyright line"
+              missing+=("$f")
+              continue
+            fi
+
+            echo "  OK"
           done
 
-          if [ -n "$MISSING" ]; then
-            echo "❌ Missing required header in:"
-            for f in $MISSING; do echo " - $f"; done
-            echo ""
-            echo "Each changed .cs file must start with:"
+          echo
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "Missing required header in:"
+            printf ' - %s\n' "${missing[@]}"
+            echo
+            echo "Each checked .cs file must contain within the first 20 lines:"
             echo "// SPDX-License-Identifier: LGPL-3.0-or-later"
-            echo "// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors"
+            echo "// Copyright (c) 2020-2026 Michal Dengusiak & Jakub Ziolkowski and contributors"
             exit 1
           fi
 
-          echo "✅ SPDX + copyright headers OK."
+          echo "SPDX + copyright headers OK."

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,14 @@
       that and don't overwrite. Local dev builds leave both empty -> no SHA attribute emitted.
     -->
     <InformationalVersion Condition="'$(InformationalVersion)' == '' AND '$(SAMSourceRevision)' != ''">$(SAMVersion)+$(SAMSourceRevision)</InformationalVersion>
+    <!--
+      Suppress the SDK's SourceLink auto-append behaviour. By default, when SourceLink is
+      configured on a project (via NuGet or repo settings), the SDK appends the project's
+      OWN commit SHA to InformationalVersion (e.g. '2026.2.164.0+998af06.dd02a4c2...').
+      We set InformationalVersion explicitly to SAM_Deploy's SHA (which encodes all 22
+      submodule pointers), so the SDK's extra append is noise. False = keep our value clean.
+    -->
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,39 @@
+<Project>
+
+  <PropertyGroup>
+    <!-- Local dev builds default to 1.0.0.0. CI passes /p:SAMVersion=YYYY.Q.<run_number>. -->
+    <SAMVersion Condition="'$(SAMVersion)' == ''">1.0.0.0</SAMVersion>
+    <AssemblyVersion>$(SAMVersion)</AssemblyVersion>
+    <FileVersion>$(SAMVersion)</FileVersion>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <!--
+    Projects where SDK assembly-attribute generation is disabled (legacy AssemblyInfo.cs
+    with GenerateAssemblyInfo=false) OR projects where the SDK doesn't auto-generate
+    attributes at all (classic-style csprojs that don't set the property — '' evaluates
+    as not 'true') ignore the AssemblyVersion/FileVersion MSBuild properties above.
+    Inject the attributes via a generated source file so those assemblies also get
+    stamped by CI.
+  -->
+  <Target Name="_GenerateSAMVersionFile"
+          BeforeTargets="CoreCompile"
+          Condition="'$(GenerateAssemblyInfo)' != 'true'">
+    <ItemGroup>
+      <_SAMVersionLine Include="// &lt;auto-generated /&gt;" />
+      <_SAMVersionLine Include="[assembly: System.Reflection.AssemblyVersionAttribute(&quot;$(SAMVersion)&quot;)]" />
+      <_SAMVersionLine Include="[assembly: System.Reflection.AssemblyFileVersionAttribute(&quot;$(SAMVersion)&quot;)]" />
+    </ItemGroup>
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)SAMVersion.g.cs"
+      Lines="@(_SAMVersionLine)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)SAMVersion.g.cs" KeepDuplicates="false" />
+      <FileWrites Include="$(IntermediateOutputPath)SAMVersion.g.cs" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,17 @@
 <Project>
 
   <PropertyGroup>
-    <!-- Local dev builds default to 1.0.0.0. CI passes /p:SAMVersion=YYYY.Q.<run_number>. -->
+    <!-- Local dev builds default to 1.0.0.0. CI passes /p:SAMVersion=YYYY.Q.<run_number>.0. -->
     <SAMVersion Condition="'$(SAMVersion)' == ''">1.0.0.0</SAMVersion>
     <AssemblyVersion>$(SAMVersion)</AssemblyVersion>
     <FileVersion>$(SAMVersion)</FileVersion>
+    <!--
+      InformationalVersion: the content-identity stamp (SemVer +build metadata).
+      Composed from SAMVersion + SAMSourceRevision when CI sets the latter. If CI already
+      set InformationalVersion directly (e.g. SAM_Deploy installer.yml does this), respect
+      that and don't overwrite. Local dev builds leave both empty -> no SHA attribute emitted.
+    -->
+    <InformationalVersion Condition="'$(InformationalVersion)' == '' AND '$(SAMSourceRevision)' != ''">$(SAMVersion)+$(SAMSourceRevision)</InformationalVersion>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
 
@@ -23,6 +30,9 @@
       <_SAMVersionLine Include="// &lt;auto-generated /&gt;" />
       <_SAMVersionLine Include="[assembly: System.Reflection.AssemblyVersionAttribute(&quot;$(SAMVersion)&quot;)]" />
       <_SAMVersionLine Include="[assembly: System.Reflection.AssemblyFileVersionAttribute(&quot;$(SAMVersion)&quot;)]" />
+      <!-- Only emit InformationalVersion attribute when CI provided a value (SDK projects
+           would otherwise get it via PropertyGroup -> SDK auto-gen). -->
+      <_SAMVersionLine Include="[assembly: System.Reflection.AssemblyInformationalVersionAttribute(&quot;$(InformationalVersion)&quot;)]" Condition="'$(InformationalVersion)' != ''" />
     </ItemGroup>
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <WriteLinesToFile

--- a/Grasshopper/SAM.Analytical.Grasshopper.GEM/Kernel/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper.GEM/Kernel/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using Grasshopper.Kernel;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
 using System;
 using System.Drawing;
 

--- a/Grasshopper/SAM.Analytical.Grasshopper.GEM/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper.GEM/Properties/AssemblyInfo.cs
@@ -54,6 +54,3 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Analytical.Grasshopper.GEM/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper.GEM/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-﻿/*
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020-2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+/*
  * This file is part of the Sustaiable Analytical Model (SAM)
  * Copyright (c) 2020, the respective contributors. All rights reserved.
  *
@@ -53,5 +55,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Analytical.Grasshopper.GEM/SAM.Analytical.Grasshopper.GEM.csproj
+++ b/Grasshopper/SAM.Analytical.Grasshopper.GEM/SAM.Analytical.Grasshopper.GEM.csproj
@@ -12,7 +12,6 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-	  <Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/Grasshopper/SAM.Analytical.Grasshopper.GEM/SAM.Analytical.Grasshopper.GEM.csproj
+++ b/Grasshopper/SAM.Analytical.Grasshopper.GEM/SAM.Analytical.Grasshopper.GEM.csproj
@@ -64,9 +64,7 @@
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.3</Version>
-    </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
   <PropertyGroup />
   <PropertyGroup>

--- a/Grasshopper/SAM.Analytical.Grasshopper.GEM/SAM.Analytical.Grasshopper.GEM.csproj
+++ b/Grasshopper/SAM.Analytical.Grasshopper.GEM/SAM.Analytical.Grasshopper.GEM.csproj
@@ -64,7 +64,7 @@
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <PropertyGroup />
   <PropertyGroup>

--- a/Grasshopper/SAM.Core.Grasshopper.GEM/Kernel/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Core.Grasshopper.GEM/Kernel/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using Grasshopper.Kernel;
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
 using System;
 using System.Drawing;
 

--- a/Grasshopper/SAM.Core.Grasshopper.GEM/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Core.Grasshopper.GEM/Properties/AssemblyInfo.cs
@@ -54,6 +54,3 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Core.Grasshopper.GEM/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Core.Grasshopper.GEM/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-﻿/*
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020-2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+/*
  * This file is part of the Sustaiable Analytical Model (SAM)
  * Copyright (c) 2020, the respective contributors. All rights reserved.
  *
@@ -53,5 +55,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Core.Grasshopper.GEM/SAM.Core.Grasshopper.GEM.csproj
+++ b/Grasshopper/SAM.Core.Grasshopper.GEM/SAM.Core.Grasshopper.GEM.csproj
@@ -12,7 +12,6 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-	  <Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/Grasshopper/SAM.Core.Grasshopper.GEM/SAM.Core.Grasshopper.GEM.csproj
+++ b/Grasshopper/SAM.Core.Grasshopper.GEM/SAM.Core.Grasshopper.GEM.csproj
@@ -31,9 +31,7 @@
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.3</Version>
-    </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
   <PropertyGroup />
   <PropertyGroup>

--- a/Grasshopper/SAM.Core.Grasshopper.GEM/SAM.Core.Grasshopper.GEM.csproj
+++ b/Grasshopper/SAM.Core.Grasshopper.GEM/SAM.Core.Grasshopper.GEM.csproj
@@ -31,7 +31,7 @@
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <PropertyGroup />
   <PropertyGroup>

--- a/SAM_GEM/SAM.Analytical.GEM/Properties/AssemblyInfo.cs
+++ b/SAM_GEM/SAM.Analytical.GEM/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿/*
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+/*
  * This file is part of the Sustaiable Analytical Model (SAM)
  * Copyright (c) 2020, the respective contributors. All rights reserved.
  *

--- a/SAM_GEM/SAM.Analytical.GEM/SAM.Analytical.GEM.csproj
+++ b/SAM_GEM/SAM.Analytical.GEM/SAM.Analytical.GEM.csproj
@@ -2,13 +2,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>SAM.Analytical</AssemblyTitle>
     <Product>SAM.Analytical</Product>
     <Copyright>Copyright (c) 2020-2026 Michal Dengusiak &amp; Jakub Ziolkowski and contributors</Copyright>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/SAM_GEM/SAM.Analytical.GEM/SAM.Analytical.GEM.csproj
+++ b/SAM_GEM/SAM.Analytical.GEM/SAM.Analytical.GEM.csproj
@@ -6,9 +6,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>SAM.Analytical</AssemblyTitle>
     <Product>SAM.Analytical</Product>
-    <Copyright>Copyright ©  2020</Copyright>
-    <AssemblyVersion>1.0.%2a</AssemblyVersion>
-    <FileVersion>1.0.%2a</FileVersion>
+    <Copyright>Copyright (c) 2020-2026 Michal Dengusiak &amp; Jakub Ziolkowski and contributors</Copyright>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/SAM_GEM/SAM.Analytical.GEM/SAM.Analytical.GEM.csproj
+++ b/SAM_GEM/SAM.Analytical.GEM/SAM.Analytical.GEM.csproj
@@ -36,6 +36,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/SAM_GEM/SAM.Analytical.GEM/SAM.Analytical.GEM.csproj
+++ b/SAM_GEM/SAM.Analytical.GEM/SAM.Analytical.GEM.csproj
@@ -36,6 +36,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/SAM_GEM/SAM.Core.GEM/Properties/AssemblyInfo.cs
+++ b/SAM_GEM/SAM.Core.GEM/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿/*
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+/*
  * This file is part of the Sustaiable Analytical Model (SAM)
  * Copyright (c) 2020, the respective contributors. All rights reserved.
  *

--- a/SAM_GEM/SAM.Core.GEM/SAM.Core.GEM.csproj
+++ b/SAM_GEM/SAM.Core.GEM/SAM.Core.GEM.csproj
@@ -2,13 +2,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>SAM</AssemblyTitle>
     <Product>SAM</Product>
     <Copyright>Copyright (c) 2020-2026 Michal Dengusiak &amp; Jakub Ziolkowski and contributors</Copyright>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/SAM_GEM/SAM.Core.GEM/SAM.Core.GEM.csproj
+++ b/SAM_GEM/SAM.Core.GEM/SAM.Core.GEM.csproj
@@ -6,9 +6,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>SAM</AssemblyTitle>
     <Product>SAM</Product>
-    <Copyright>Copyright ©  2020</Copyright>
-    <AssemblyVersion>1.0.%2a</AssemblyVersion>
-    <FileVersion>1.0.%2a</FileVersion>
+    <Copyright>Copyright (c) 2020-2026 Michal Dengusiak &amp; Jakub Ziolkowski and contributors</Copyright>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/SAM_GEM/SAM.Core.GEM/SAM.Core.GEM.csproj
+++ b/SAM_GEM/SAM.Core.GEM/SAM.Core.GEM.csproj
@@ -21,6 +21,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/SAM_GEM/SAM.Core.GEM/SAM.Core.GEM.csproj
+++ b/SAM_GEM/SAM.Core.GEM/SAM.Core.GEM.csproj
@@ -21,6 +21,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/SAM_GEM/SAM.Geometry.GEM/Properties/AssemblyInfo.cs
+++ b/SAM_GEM/SAM.Geometry.GEM/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿/*
+﻿// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+/*
  * This file is part of the Sustaiable Analytical Model (SAM)
  * Copyright (c) 2020, the respective contributors. All rights reserved.
  *

--- a/SAM_GEM/SAM.Geometry.GEM/SAM.Geometry.GEM.csproj
+++ b/SAM_GEM/SAM.Geometry.GEM/SAM.Geometry.GEM.csproj
@@ -29,6 +29,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/SAM_GEM/SAM.Geometry.GEM/SAM.Geometry.GEM.csproj
+++ b/SAM_GEM/SAM.Geometry.GEM/SAM.Geometry.GEM.csproj
@@ -2,13 +2,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>SAM</AssemblyTitle>
     <Product>SAM</Product>
     <Copyright>Copyright (c) 2020-2026 Michal Dengusiak &amp; Jakub Ziolkowski and contributors</Copyright>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/SAM_GEM/SAM.Geometry.GEM/SAM.Geometry.GEM.csproj
+++ b/SAM_GEM/SAM.Geometry.GEM/SAM.Geometry.GEM.csproj
@@ -6,9 +6,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>SAM</AssemblyTitle>
     <Product>SAM</Product>
-    <Copyright>Copyright ©  2020</Copyright>
-    <AssemblyVersion>1.0.%2a</AssemblyVersion>
-    <FileVersion>1.0.%2a</FileVersion>
+    <Copyright>Copyright (c) 2020-2026 Michal Dengusiak &amp; Jakub Ziolkowski and contributors</Copyright>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/SAM_GEM/SAM.Geometry.GEM/SAM.Geometry.GEM.csproj
+++ b/SAM_GEM/SAM.Geometry.GEM/SAM.Geometry.GEM.csproj
@@ -29,6 +29,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Quarterly Q2 2026 work from the SAM-BIM fork merging back into the upstream.
Includes the **Newtonsoft.Json → System.Text.Json.Nodes** migration of the
entire SAM-BIM stack (per-repo PRs already merged into SAM-BIM's `sow/2026-Q2`).

## Highlights of this quarter

- All `IJSAMObject` implementations migrated from `JObject`/`JArray`/`JToken` to
  `JsonObject`/`JsonArray`/`JsonNode`.
- `FromJObject` / `ToJObject` renamed to `FromJsonObject` / `ToJsonObject`.
- `System.Text.Json` 10.0.8 replaces `Newtonsoft.Json` 13.0.3 in every csproj
  (except SAM_Revit which keeps Newtonsoft loadable for Revit's runtime).
- Wire format preserved bit-for-bit (14 fixture round-trip tests in SAM/SAM.Tests).
- 5 latent pre-existing bugs fixed (DateTime/string bleed, NCMData enum round-trip,
  Log identity loss, SearchWrapper missing type discriminator, RelationCollection
  wrong-jObject-passed).

## Verification

- Full `BuildAlls_v3 RestoreCleanRebuild` against the merged sow/2026-Q2 chain:
  **0 errors, 144 artifacts**.
- All 32 per-repo migration PRs on SAM-BIM:sow/2026-Q2 passed build + spdx CI.
- Local Rhino / Revit / Tas runtime smoke validated.

## Test plan

- [ ] Upstream CI builds (if configured)
- [ ] Reviewer spot-check of `IJSAMObject` API rename
- [ ] After merge, downstream forks sync `master` from upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)
